### PR TITLE
Feature/collection content review

### DIFF
--- a/zebedee/collection.go
+++ b/zebedee/collection.go
@@ -150,3 +150,71 @@ func (z *zebedeeClient) UpdateCollectionContent(
 
 	return nil
 }
+
+//DeleteCollectionContent deletes content from a collection
+func (z *zebedeeClient) DeleteCollectionContent(s Session, id, contentUri string) error {
+	uri := fmt.Sprintf("/content/%s?uri=%s", id, contentUri)
+
+	req, err := z.newAuthenticatedRequest(uri, s.ID, http.MethodDelete, nil)
+	if err != nil {
+		return err
+	}
+
+	var success bool
+	err = z.requestObject(req, http.StatusOK, &success)
+	if err != nil {
+		return err
+	}
+
+	if !success {
+		return fmt.Errorf("delete collection content request unsuccessful: %s", id)
+	}
+
+	return nil
+}
+
+//CompleteCollectionContent sets content in a collection to the complete state.
+// This is done once the content has been updated and the user is satisfied that the changes are complete
+func (z *zebedeeClient) CompleteCollectionContent(s Session, id, contentUri string, recursive bool) error {
+	uri := fmt.Sprintf("/complete/%s?uri=%s&recursive=%t", id, contentUri, recursive)
+
+	req, err := z.newAuthenticatedRequest(uri, s.ID, http.MethodPost, nil)
+	if err != nil {
+		return err
+	}
+
+	var success bool
+	err = z.requestObject(req, http.StatusOK, &success)
+	if err != nil {
+		return err
+	}
+
+	if !success {
+		return fmt.Errorf("complete collection content request unsuccessful: %s", id)
+	}
+
+	return nil
+}
+
+//ReviewCollectionContent sets content in a collection to the reviewed state.
+// This is done once the content has been reviewed by a user who is not the original editor.
+func (z *zebedeeClient) ReviewCollectionContent(s Session, id, contentUri string, recursive bool) error {
+	uri := fmt.Sprintf("/review/%s?uri=%s&recursive=%t", id, contentUri, recursive)
+
+	req, err := z.newAuthenticatedRequest(uri, s.ID, http.MethodPost, nil)
+	if err != nil {
+		return err
+	}
+
+	var success bool
+	err = z.requestObject(req, http.StatusOK, &success)
+	if err != nil {
+		return err
+	}
+
+	if !success {
+		return fmt.Errorf("review collection content request unsuccessful: %s", id)
+	}
+
+	return nil
+}

--- a/zebedee/zebedee.go
+++ b/zebedee/zebedee.go
@@ -18,6 +18,9 @@ type CollectionsAPI interface {
 	GetCollections(s Session) ([]CollectionDescription, error)
 	UpdateCollection(s Session, desc CollectionDescription) error
 	UpdateCollectionContent(s Session, id, contentUri string, content io.Reader, overwriteExisting, recursive, validateJson bool) error
+	DeleteCollectionContent(s Session, id, contentUri string) error
+	CompleteCollectionContent(s Session, id string, contentUri string, recursive bool) error
+	ReviewCollectionContent(s Session, id string, contentUri string, recursive bool) error
 }
 
 //PermissionsAPI defines the user permissions endpoints in Zebedee CMS


### PR DESCRIPTION
- Add Zebedee collection functions to complete/review/delete collection content
- Use `fmt.Sprintf` instead of string concat to build expected URL's in tests