### PR TITLE
added API error type to hold details about the response body and status

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1y
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=

--- a/zebedee/http.go
+++ b/zebedee/http.go
@@ -3,21 +3,35 @@ package zebedee
 import (
 	"context"
 	"fmt"
-	dphttp "github.com/ONSdigital/dp-net/http"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	dphttp "github.com/ONSdigital/dp-net/http"
 )
 
 const (
+	readResponseBodyErrFmt        = "unexpected error attempting to read error response body: %q %s %s expected status: %d actual status: %d"
 	incorrectStatusErrFmt         = "request %s %s expected status %d but received %d"
-	incorrectStatusWithBodyErrFmt = "request %s %s expected status %d but received %d response body: %s"
+	incorrectStatusWithBodyErrFmt = "request %s %s expected status %d but received %d"
 )
 
 //go:generate moq -out mock/httpclient.go -pkg mock . HttpClient
 // HttpClient defines a Zebedee HTTP client
 type HttpClient interface {
 	Do(ctx context.Context, req *http.Request) (*http.Response, error)
+}
+
+// APIError represent an error returned from the Zebedee CMS API.
+type APIError struct {
+	ActualStatus   int
+	ExpectedStatus int
+	Message        string
+	Body           string
+}
+
+func (err *APIError) Error() string {
+	return err.Message
 }
 
 //NewHttpClient Construct a new HttpClient
@@ -31,14 +45,27 @@ func checkResponseStatus(resp *http.Response, expected int) error {
 	if resp.StatusCode != expected {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("unexpected error attempting to read error response body: %s", err.Error())
+			return &APIError{
+				ActualStatus:   resp.StatusCode,
+				ExpectedStatus: expected,
+				Message:        fmt.Sprintf(readResponseBodyErrFmt, err.Error(), req.Method, req.URL.RequestURI(), expected, resp.StatusCode),
+			}
 		}
 
 		if len(body) > 0 {
-			return fmt.Errorf(incorrectStatusWithBodyErrFmt, req.Method, req.URL.RequestURI(), expected, resp.StatusCode, string(body))
+			return &APIError{
+				ActualStatus:   resp.StatusCode,
+				ExpectedStatus: expected,
+				Body:           string(body),
+				Message:        fmt.Sprintf(incorrectStatusWithBodyErrFmt, req.Method, req.URL.RequestURI(), expected, resp.StatusCode),
+			}
 		}
 
-		return fmt.Errorf(incorrectStatusErrFmt, req.Method, req.URL.RequestURI(), expected, resp.StatusCode)
+		return &APIError{
+			ActualStatus:   resp.StatusCode,
+			ExpectedStatus: expected,
+			Message:        fmt.Sprintf(incorrectStatusErrFmt, req.Method, req.URL.RequestURI(), expected, resp.StatusCode),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Added new `APIError` type as a custom error to hold extra details about errors return when calling the CMS API.